### PR TITLE
Make compatible with capistrano-bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Other than that, this plugin does not need any setup.
 
 Run:
 
-    $ bundle exec production deploy
+    $ bundle exec cap production deploy
 
 And watch ruby being installed.
 

--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -45,7 +45,6 @@ namespace :rbenv do
     end
   end
 
-
   desc 'Install bundler gem'
   task :install_bundler do
     on roles fetch(:rbenv_roles) do

--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -27,6 +27,14 @@ namespace :rbenv do
     end
   end
 
+  desc 'Update ruby build - rbenv plugin'
+  task :update_ruby_build do
+    on roles fetch(:rbenv_roles) do
+      next if test "[ ! -d #{rbenv_ruby_build_path} ]"
+      execute :git, "-C #{rbenv_ruby_build_path}", :pull
+    end
+  end
+
   desc 'Install ruby'
   task :install_ruby do
     on roles fetch(:rbenv_roles) do
@@ -34,6 +42,7 @@ namespace :rbenv do
       execute rbenv_bin_executable_path, :install, fetch(:rbenv_ruby)
     end
   end
+
 
   desc 'Install bundler gem'
   task :install_bundler do
@@ -69,7 +78,9 @@ namespace :rbenv do
   end
 
   before 'rbenv:validate', 'rbenv:install'
+  before 'rbenv:install_ruby', 'rbenv:update_rbenv'
   after 'rbenv:map_bins', 'rbenv:install_bundler'
+
   before 'rbenv:install_bundler', 'rbenv:install:remove_bundler_binmaps'
   after 'rbenv:install_bundler', 'rbenv:install:reinsert_bundler_binmaps'
 end

--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -31,7 +31,9 @@ namespace :rbenv do
   task :update_ruby_build do
     on roles fetch(:rbenv_roles) do
       next if test "[ ! -d #{rbenv_ruby_build_path} ]"
-      execute :git, "-C #{rbenv_ruby_build_path}", :pull
+      within rbenv_ruby_build_path do
+        execute :git, :pull
+      end
     end
   end
 

--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -56,7 +56,7 @@ namespace :rbenv do
     task :reinsert_bundler_binmaps do
       on roles fetch(:rbenv_roles) do
         next unless Rake::Task.task_defined?('bundler:map_bins')
-        SSHKit.config.command_map.insert(1,'bundle exec')
+        SSHKit.config.command_map.prefix[:gem].insert(1,'bundle exec')
       end
     end
   end

--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -78,7 +78,7 @@ namespace :rbenv do
   end
 
   before 'rbenv:validate', 'rbenv:install'
-  before 'rbenv:install_ruby', 'rbenv:update_rbenv'
+  before 'rbenv:install_ruby', 'rbenv:update_ruby_build'
   after 'rbenv:map_bins', 'rbenv:install_bundler'
 
   before 'rbenv:install_bundler', 'rbenv:install:remove_bundler_binmaps'

--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -39,13 +39,7 @@ namespace :rbenv do
   task :install_bundler do
     on roles fetch(:rbenv_roles) do
       next if test :gem, :query, '--quiet --installed --name-matches ^bundler$'
-
-      bundle_exec_index = SSHKit.config.command_map.prefix[:gem].index('bundle exec')
-      SSHKit.config.command_map.prefix[:gem].reject! { |c| c == 'bundle exec' } unless bundle_exec_index.nil?
-
       execute :gem, :install, :bundler, '--quiet --no-rdoc --no-ri'
-
-      SSHKit.config.command_map.prefix[:gem].insert(bundle_exec_index, 'bundle exec') unless bundle_exec_index.nil?
     end
   end
 


### PR DESCRIPTION
Avoid the "bundle exec" prefixes when Capistrano tries to run `rbenv:install_bundler` when you have capistrano-bundler enabled at the same time.

Also updates ruby-builder before running rbenv:install_ruby. Good to have when you need upgrade.

Fixes typo in Readme.
