### PR TITLE
Dependencies installation task added

### DIFF
--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -14,6 +14,7 @@ namespace :rbenv do
   desc 'Install required dependencies for Ruby compiling'
   task :install_dependencies do
     on roles fetch(:rbenv_roles) do
+      next if test "[ -d #{fetch(:rbenv_path)} ]"
       sudo 'apt-get install -y libssl-dev libreadline-dev zlib1g-dev'
     end
   end

--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -11,6 +11,13 @@ include Capistrano::DSL::RbenvInstall
 # set :rbenv_ruby_dir           # "#{fetch(:rbenv_path)}/versions/#{fetch(:rbenv_ruby)}" }
 
 namespace :rbenv do
+  desc 'Install required dependencies for Ruby compiling'
+  task :install_dependencies do
+    on roles fetch(:rbenv_roles) do
+      execute 'apt-get install -y libssl-dev libreadline-dev zlib1g-dev'
+    end
+  end
+
   desc 'Install rbenv'
   task :install_rbenv do
     on roles fetch(:rbenv_roles) do
@@ -56,6 +63,7 @@ namespace :rbenv do
 
   desc 'Install rbenv, ruby build and ruby version'
   task :install do
+    invoke 'rbenv:install_dependencies'
     invoke 'rbenv:install_rbenv'
     invoke 'rbenv:install_ruby_build'
     invoke 'rbenv:install_ruby'

--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -14,7 +14,7 @@ namespace :rbenv do
   desc 'Install required dependencies for Ruby compiling'
   task :install_dependencies do
     on roles fetch(:rbenv_roles) do
-      execute 'apt-get install -y libssl-dev libreadline-dev zlib1g-dev'
+      sudo 'apt-get install -y libssl-dev libreadline-dev zlib1g-dev'
     end
   end
 


### PR DESCRIPTION
The compilation of Ruby depends on several Linux packages which can be installed with `rbenv:install_dependencies` task, which runs first in rbenv:install task. 