### PR TITLE
Set bundler install options through 'rbenv_bundler_options'

### DIFF
--- a/lib/capistrano/tasks/rbenv_install.rake
+++ b/lib/capistrano/tasks/rbenv_install.rake
@@ -50,7 +50,7 @@ namespace :rbenv do
   task install_bundler: ['rbenv:map_bins'] do
     on roles fetch(:rbenv_roles) do
       next if test :gem, :query, '--quiet --installed --name-matches ^bundler$'
-      execute :gem, :install, :bundler, '--quiet --no-rdoc --no-ri'
+      execute :gem, :install, :bundler, fetch(:rbenv_bundler_options, '--quiet --no-rdoc --no-ri')
     end
   end
 


### PR DESCRIPTION
As of now rbenv installing ruby version < 2.3 has issues installing the bundler. Hence there should be a option to set the version of the bundler which needs to be installed.

With installing ruby < 2.3, we end up with below error
```
SSHKit::Command::Failed: gem exit status: 1
gem stdout: ERROR:  Error installing bundler:
	bundler requires Ruby version >= 2.3.0.
gem stderr: Nothing written
```